### PR TITLE
Vim search highlight improvement

### DIFF
--- a/.config/vim/keybindings/keybindings.vim
+++ b/.config/vim/keybindings/keybindings.vim
@@ -18,6 +18,8 @@ nnoremap <leader>wq :wq<cr>
 nnoremap <leader>ww :w<cr>
 nnoremap <leader>q :q<cr>
 
+nnoremap <CR> :noh<CR><CR>:<backspace>
+
 " Plugin keybindings
 source $XDG_CONFIG_HOME/vim/keybindings/vimspector.vim
 source $XDG_CONFIG_HOME/vim/keybindings/markdown.vim

--- a/.config/vim/vimrc
+++ b/.config/vim/vimrc
@@ -52,12 +52,6 @@ set shortmess=Iat
 " Search
 set hlsearch
 set incsearch
-" Disable highlight after a search
-augroup vimrc-incsearch-highlight
-	autocmd!
-	autocmd CmdlineEnter /,\? :set hlsearch
-	autocmd CmdlineLeave /,\? :set nohlsearch
-augroup END
 
 " Pro tab
 filetype plugin indent on


### PR DESCRIPTION
Previously highlight was disabled as soon as the text was entered into the search buffer. That was not optimal since I wished sometimes that search highlight was available, especially when tracking the origin of a variable.

The new configuration will not disable search highlight but a remap of ':noh' is done to <enter>. So whenever <enter> is pressed, search highligh is cleared